### PR TITLE
Enable auto-adding of new entities (switch, device_tracker) when a new device connects to the network.

### DIFF
--- a/custom_components/googlewifi/const.py
+++ b/custom_components/googlewifi/const.py
@@ -28,6 +28,8 @@ DEFAULT_SPEEDTEST = True
 CONF_SPEEDTEST_INTERVAL = "speedtest_interval"
 DEFAULT_SPEEDTEST_INTERVAL = 24
 CONF_SPEED_UNITS = "speed_units"
+SIGNAL_ADD_DEVICE = "googlewifi_add_device"
+SIGNAL_DELETE_DEVICE = "googlewifi_delete_device"
 
 
 def unit_convert(data_rate: float, unit_of_measurement: str):


### PR DESCRIPTION
System will now automatically add new devices which connect to the network dynamically rather than waiting for the next restart of the system. Should also auto-delete entities if they are removed from the Google Wifi Cloud platform.